### PR TITLE
Bump versions and cause script to error on bad exit codes

### DIFF
--- a/bootstrap_python.sh
+++ b/bootstrap_python.sh
@@ -1,3 +1,6 @@
+set -e
+set -o pipefail
+
 INSTALL_ROOT=$HOME/Python
 CPY=$INSTALL_ROOT/CPython
 PYPY=$INSTALL_ROOT/PyPy
@@ -9,18 +12,18 @@ CURL='wget --no-check-certificate'
 mkdir -p $INSTALL_ROOT
 
 PYTHON_2_6=2.6.9
-PYTHON_2_7=2.7.9
+PYTHON_2_7=2.7.10
 PYTHON_3_3=3.3.6
-PYTHON_3_4=3.4.2
-PY_PY=2.5.0
-SETUPTOOLS=12.0.5
-PIP=6.0.8
+PYTHON_3_4=3.4.3
+PY_PY=2.6.0
+SETUPTOOLS=18.1
+PIP=7.1.0
 
 pushd $SANDBOX
   wget ftp://ftp.cwru.edu/pub/bash/readline-6.2.tar.gz
   tar xzf readline-6.2.tar.gz
   pushd readline-6.2
-    ./configure --disable-shared --enable-static --prefix=$SANDBOX/readline
+    ./configure --disable-shared --enable-static --prefix=$SANDBOX/readline && \
     make -j3 && make install
   popd
   rm -rf readline-6.2.tar.gz readline-6.2
@@ -35,7 +38,7 @@ pushd $SANDBOX
     popd
     rm -f Python-$version.tgz
   done
-  
+
   # install pypy
   for pypy_version in $PY_PY-osx64; do
     pushd $INSTALL_ROOT
@@ -48,7 +51,7 @@ pushd $SANDBOX
 
   $CURL https://pypi.python.org/packages/source/s/setuptools/setuptools-$SETUPTOOLS.tar.gz
   $CURL http://pypi.python.org/packages/source/p/pip/pip-$PIP.tar.gz
-  
+
   for interpreter in $CPY-$PYTHON_2_6/bin/python2.6 \
                      $CPY-$PYTHON_2_7/bin/python2.7 \
                      $CPY-$PYTHON_3_3/bin/python3.3 \
@@ -63,7 +66,7 @@ pushd $SANDBOX
       rm -rf $base
     done
   done
-  
+
   rm -f setuptools-$SETUPTOOLS.tar.gz pip-$PIP.tar.gz
 popd
 


### PR DESCRIPTION
- bump versions of python and libs to the latest available
- cause script to error when a non-zero exit code is encountered rather than masking errors

cc @Yasumoto @wickman 
